### PR TITLE
Make initializers public

### DIFF
--- a/Sources/PennForms/FormComponent.swift
+++ b/Sources/PennForms/FormComponent.swift
@@ -14,13 +14,13 @@ public struct _SequenceFormComponent<C0: FormComponent, C1: FormComponent>: Form
     }
 }
 
-struct ComponentWrapper<Content: View>: FormComponent {
+public struct ComponentWrapper<Content: View>: FormComponent {
     @ViewBuilder let content: () -> Content
     
-    init(content: @escaping () -> Content) {
+    public init(content: @escaping () -> Content) {
         self.content = content
     }
-    var body: some View {
+    public var body: some View {
         content()
     }
 }

--- a/Sources/PennForms/FormComponents/DateField.swift
+++ b/Sources/PennForms/FormComponents/DateField.swift
@@ -10,7 +10,7 @@ public struct DateField: FormComponent {
     let title: String?
     let placeholder: String?
     
-    init(date: Binding<Date?>, in range: ClosedRange<Date>? = nil, title: String? = nil, placeholder: String? = nil) {
+    public init(date: Binding<Date?>, in range: ClosedRange<Date>? = nil, title: String? = nil, placeholder: String? = nil) {
         self._date = Binding(
             get: {
                 guard let d = date.wrappedValue else { return .distantFuture }
@@ -26,7 +26,7 @@ public struct DateField: FormComponent {
         self._validator = Environment(\.validator)
     }
     
-    init(date: Binding<Date>, in range: ClosedRange<Date>? = nil, title: String? = nil, placeholder: String? = nil) {
+    public init(date: Binding<Date>, in range: ClosedRange<Date>? = nil, title: String? = nil, placeholder: String? = nil) {
         self._date = date
         self.range = range
         self.title = title

--- a/Sources/PennForms/FormComponents/DateRangeField.swift
+++ b/Sources/PennForms/FormComponents/DateRangeField.swift
@@ -13,7 +13,7 @@ public struct DateRangeField: FormComponent {
     let lowerPlaceholder: String?
     let upperPlaceholder: String?
     
-    init(lowerDate: Binding<Date?>, upperDate: Binding<Date?>, in range: ClosedRange<Date>? = nil, upperOffset: Int = 0, title: String? = nil, lowerPlaceholder: String? = nil, upperPlaceholder: String? = nil) {
+    public init(lowerDate: Binding<Date?>, upperDate: Binding<Date?>, in range: ClosedRange<Date>? = nil, upperOffset: Int = 0, title: String? = nil, lowerPlaceholder: String? = nil, upperPlaceholder: String? = nil) {
         self._lowerDate = Binding(
             get: {
                 guard let d = lowerDate.wrappedValue else { return .distantPast }
@@ -67,7 +67,7 @@ public struct DateRangeField: FormComponent {
         }
     }
     
-    func dateField(date: Binding<Date>, in range: ClosedRange<Date>, placeholder: String? = nil) -> some View {
+    public func dateField(date: Binding<Date>, in range: ClosedRange<Date>, placeholder: String? = nil) -> some View {
         HStack {
             Group {
                 if date.wrappedValue == .distantFuture || date.wrappedValue == .distantPast {

--- a/Sources/PennForms/FormComponents/FormGroup.swift
+++ b/Sources/PennForms/FormComponents/FormGroup.swift
@@ -5,12 +5,12 @@ public struct FormGroup<Content: FormComponent>: FormComponent {
     @FormBuilder let content: () -> Content
     @Environment(\.validator) private var validator
     
-    init(title: String, @FormBuilder content: @escaping () -> Content) {
+    public init(title: String, @FormBuilder content: @escaping () -> Content) {
         self.title = title
         self.content = content
     }
     
-    init(@FormBuilder content: @escaping () -> Content) {
+    public init(@FormBuilder content: @escaping () -> Content) {
         self.title = nil
         self.content = content
     }

--- a/Sources/PennForms/FormComponents/NumericField.swift
+++ b/Sources/PennForms/FormComponents/NumericField.swift
@@ -9,7 +9,7 @@ public struct NumericField<FormatStyle: ParseableFormatStyle>: FormComponent whe
     @Environment(\.validator) private var validator
     
     
-    init(_ value: Binding<Int?>, placeholder: String? = nil, title: String? = nil) where FormatStyle == Decimal.FormatStyle {
+    public init(_ value: Binding<Int?>, placeholder: String? = nil, title: String? = nil) where FormatStyle == Decimal.FormatStyle {
         self._value = Binding(get: {
             guard let v = value.wrappedValue else { return .nan }
             return Decimal(v)
@@ -25,7 +25,7 @@ public struct NumericField<FormatStyle: ParseableFormatStyle>: FormComponent whe
         UITextField.appearance().textColor = .secondaryLabel
     }
     
-    init(_ value: Binding<Int?>, format: FormatStyle, placeholder: String? = nil, title: String? = nil) {
+    public init(_ value: Binding<Int?>, format: FormatStyle, placeholder: String? = nil, title: String? = nil) {
         self._value = Binding(get: {
             guard let v = value.wrappedValue else { return .nan }
             return Decimal(v)
@@ -38,7 +38,7 @@ public struct NumericField<FormatStyle: ParseableFormatStyle>: FormComponent whe
         self._validator = Environment(\.validator)
     }
     
-    init(_ value: Binding<Double?>, placeholder: String? = nil, title: String? = nil) where FormatStyle == Decimal.FormatStyle {
+    public init(_ value: Binding<Double?>, placeholder: String? = nil, title: String? = nil) where FormatStyle == Decimal.FormatStyle {
         self._value = Binding(get: {
             guard let v = value.wrappedValue else { return .nan }
             return Decimal(v)
@@ -54,7 +54,7 @@ public struct NumericField<FormatStyle: ParseableFormatStyle>: FormComponent whe
         UITextField.appearance().textColor = .secondaryLabel
     }
     
-    init(_ value: Binding<Double?>, placeholder: String? = nil, title: String? = nil, format: FormatStyle) {
+    public init(_ value: Binding<Double?>, placeholder: String? = nil, title: String? = nil, format: FormatStyle) {
         self._value = Binding(get: {
             guard let v = value.wrappedValue else { return .nan }
             return Decimal(v)

--- a/Sources/PennForms/FormComponents/OptionField.swift
+++ b/Sources/PennForms/FormComponents/OptionField.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct OptionField<Option: Hashable>: FormComponent {
+public struct OptionField<Option: Hashable>: FormComponent {
     @Binding var selection: Option?
     let options: [Option]
     let toString: (Option) -> String
@@ -9,7 +9,7 @@ struct OptionField<Option: Hashable>: FormComponent {
     
     @Environment(\.validator) var validator
     
-    init(_ selection: Binding<Option?>, options: [Option], toString: @escaping (Option) -> String, title: String? = nil, placeholder: String? = nil) {
+    public init(_ selection: Binding<Option?>, options: [Option], toString: @escaping (Option) -> String, title: String? = nil, placeholder: String? = nil) {
         self._selection = selection
         self.options = options
         self.toString = toString
@@ -17,7 +17,7 @@ struct OptionField<Option: Hashable>: FormComponent {
         self.placeholder = placeholder
     }
     
-    init(_ selection: Binding<Option?>, options: [Option], title: String? = nil, placeholder: String? = nil) where Option: CaseIterable, Option: RawRepresentable<String> {
+    public init(_ selection: Binding<Option?>, options: [Option], title: String? = nil, placeholder: String? = nil) where Option: CaseIterable, Option: RawRepresentable<String> {
         self._selection = selection
         self.options = options
         self.toString = { $0.rawValue }
@@ -25,7 +25,7 @@ struct OptionField<Option: Hashable>: FormComponent {
         self.placeholder = placeholder
     }
     
-    init(_ selection: Binding<Option?>, range: ClosedRange<Int>, title: String? = nil, placeholder: String? = nil) where Option == Int, Option: LosslessStringConvertible {
+    public init(_ selection: Binding<Option?>, range: ClosedRange<Int>, title: String? = nil, placeholder: String? = nil) where Option == Int, Option: LosslessStringConvertible {
         self._selection = selection
         self.options = Array(range)
         self.toString = { $0.description }
@@ -33,7 +33,7 @@ struct OptionField<Option: Hashable>: FormComponent {
         self.placeholder = placeholder
     }
     
-    var body: some View {
+    public var body: some View {
         VStack(alignment: .leading) {
             if let title {
                 Text(title)

--- a/Sources/PennForms/FormComponents/PairFields.swift
+++ b/Sources/PennForms/FormComponents/PairFields.swift
@@ -3,7 +3,7 @@ import SwiftUI
 public struct PairFields<Content: View>: FormComponent {
     @ViewBuilder let content: () -> Content
     
-    init(@ViewBuilder content: @escaping () -> Content) {
+    public init(@ViewBuilder content: @escaping () -> Content) {
         self.content = content
     }
     

--- a/Sources/PennForms/FormComponents/TagSelector.swift
+++ b/Sources/PennForms/FormComponents/TagSelector.swift
@@ -11,12 +11,12 @@ public struct TagSelector<Tag: Hashable>: FormComponent {
     @Environment(\.validator) var validator
     @Environment(\.colorScheme) var colorScheme
     
-    enum Customisable {
+    public enum Customisable {
         case notCustomisable
         case customisable(tagFromString: (String) -> Tag)
     }
     
-    init(selection: Binding<OrderedSet<Tag>>, tags: Binding<OrderedSet<Tag>>, toString: @escaping (Tag) -> String, _ customisable: Customisable = .notCustomisable, title: String? = nil) {
+    public init(selection: Binding<OrderedSet<Tag>>, tags: Binding<OrderedSet<Tag>>, toString: @escaping (Tag) -> String, _ customisable: Customisable = .notCustomisable, title: String? = nil) {
         self._selection = selection
         self._tags = tags
         self.toString = toString
@@ -25,7 +25,7 @@ public struct TagSelector<Tag: Hashable>: FormComponent {
         self._validator = Environment(\.validator)
     }
     
-    init(selection: Binding<OrderedSet<Tag>>, tags: Binding<OrderedSet<Tag>>, customisable: Customisable = .notCustomisable, title: String? = nil) where Tag: RawRepresentable<String> {
+    public init(selection: Binding<OrderedSet<Tag>>, tags: Binding<OrderedSet<Tag>>, customisable: Customisable = .notCustomisable, title: String? = nil) where Tag: RawRepresentable<String> {
         self._selection = selection
         self._tags = tags
         self.toString = { $0.rawValue }
@@ -34,7 +34,7 @@ public struct TagSelector<Tag: Hashable>: FormComponent {
         self._validator = Environment(\.validator)
     }
     
-    init(selection: Binding<OrderedSet<Tag>>, tags: Binding<OrderedSet<Tag>>, customisable: Customisable = .notCustomisable, title: String? = nil) where Tag: LosslessStringConvertible {
+    public init(selection: Binding<OrderedSet<Tag>>, tags: Binding<OrderedSet<Tag>>, customisable: Customisable = .notCustomisable, title: String? = nil) where Tag: LosslessStringConvertible {
         self._selection = selection
         self._tags = tags
         self.toString = { $0.description }

--- a/Sources/PennForms/FormComponents/TextAreaField.swift
+++ b/Sources/PennForms/FormComponents/TextAreaField.swift
@@ -8,14 +8,14 @@ public struct TextAreaField: FormComponent {
     
     @Environment(\.validator) var validator
     
-    init(_ text: Binding<String>, characterCount: Int? = nil, title: String? = nil) {
+    public init(_ text: Binding<String>, characterCount: Int? = nil, title: String? = nil) {
         self._text = text
         self.characterCount = characterCount
         self.title = title
         self._validator = Environment(\.validator)
     }
     
-    init(_ text: Binding<String?>, characterCount: Int? = nil, title: String? = nil) {
+    public init(_ text: Binding<String?>, characterCount: Int? = nil, title: String? = nil) {
         self._text = Binding(
             get: {
                 guard let t = text.wrappedValue else { return "∞" }

--- a/Sources/PennForms/FormComponents/TextLineField.swift
+++ b/Sources/PennForms/FormComponents/TextLineField.swift
@@ -6,14 +6,14 @@ public struct TextLineField: FormComponent {
     let title: String?
     @Environment(\.validator) private var validator
     
-    init(_ text: Binding<String>, placeholder: String? = nil, title: String? = nil) {
+    public init(_ text: Binding<String>, placeholder: String? = nil, title: String? = nil) {
         self._text = text
         self.placeholder = placeholder
         self.title = title
         self._validator = Environment(\.validator)
     }
     
-    init(_ text: Binding<String?>, placeholder: String? = nil, title: String? = nil) {
+    public init(_ text: Binding<String?>, placeholder: String? = nil, title: String? = nil) {
         self._text = Binding(
             get: {
                 guard let t = text.wrappedValue else { return "∞" }

--- a/Sources/PennForms/LabsForm.swift
+++ b/Sources/PennForms/LabsForm.swift
@@ -13,7 +13,7 @@ public struct LabsForm<Content: FormComponent>: View {
     @FormBuilder let content: (FormState) -> Content
     @State private var formState: FormState = .init(isValid: true)
     
-    init(@FormBuilder content: @escaping (FormState) -> Content) {
+    public init(@FormBuilder content: @escaping (FormState) -> Content) {
         self.content = content
     }
     

--- a/Sources/PennForms/Validators/AnyValidator.swift
+++ b/Sources/PennForms/Validators/AnyValidator.swift
@@ -7,7 +7,7 @@ public struct AnyValidator: Validator {
         self.validator(input)
     }
     
-    init<V: Validator>(_ validator: V) where V.Input: Any {
+    public init<V: Validator>(_ validator: V) where V.Input: Any {
         self.validator = { input in
             guard let castInput = input as? V.Input else { return false}
             return validator.isValid(castInput)
@@ -15,7 +15,7 @@ public struct AnyValidator: Validator {
         self.message = validator.message
     }
     
-    init(_ isValid: @escaping () -> Bool, message: String? = nil) {
+    public init(_ isValid: @escaping () -> Bool, message: String? = nil) {
         self.validator = { _ in isValid() }
         self.message = message
         

--- a/Sources/PennForms/Validators/MergeValidator.swift
+++ b/Sources/PennForms/Validators/MergeValidator.swift
@@ -4,7 +4,7 @@ public struct ManyValidators: Validator {
     public typealias Input = Any
     let validators: [AnyValidator]
     
-    init(_ validators: [AnyValidator]) {
+    public init(_ validators: [AnyValidator]) {
         self.validators = validators
         self.message =  validators[0].message
     }


### PR DESCRIPTION
Previously, several PennForm initializers were implicitly set to internal availability, preventing the use of many PennForms structs in Penn Mobile. This PR rectifies that with a healthy dose of `public init`.
