### PR TITLE
Make date fields use sheets instead of DatePicker overlay

### DIFF
--- a/Sources/PennForms/FormComponents/DateField.swift
+++ b/Sources/PennForms/FormComponents/DateField.swift
@@ -101,19 +101,22 @@ internal struct DatePickerPopover: View {
     
     var innerBody: some View {
         NavigationStack {
-            DatePicker("", selection: $date, in: range, displayedComponents: [.date])
-                .datePickerStyle(.graphical)
-                .padding(.horizontal)
-                .navigationTitle(title ?? "Select Date")
-                .navigationBarTitleDisplayMode(.inline)
-                .toolbar {
-                    ToolbarItem(placement: .primaryAction) {
-                        Button("Done") {
-                            dismiss()
-                        }
+            ScrollView {
+                VStack(spacing: 0) {
+                    DatePicker("", selection: $date, in: range, displayedComponents: [.date])
+                        .datePickerStyle(.graphical)
+                    
+                    Button("Select") {
+                        dismiss()
                     }
+                    .buttonBorderShape(.capsule)
+                    .buttonStyle(BorderedProminentButtonStyle())
+                    .fontWeight(.bold)
                 }
-                .frame(width: 400, height: 480, alignment: .top)
+                .padding([.horizontal, .bottom])
+            }
+            .navigationTitle(title ?? "Select Date")
+            .navigationBarTitleDisplayMode(.inline)
         }
         .presentationDetents([.height(500)])
         .presentationDragIndicator(.visible)

--- a/Sources/PennForms/FormComponents/DateField.swift
+++ b/Sources/PennForms/FormComponents/DateField.swift
@@ -99,7 +99,7 @@ internal struct DatePickerPopover: View {
     @Environment(\.dismiss) var dismiss
     @Environment(\.verticalSizeClass) var sizeClass
     
-    var body: some View {
+    var innerBody: some View {
         NavigationStack {
             DatePicker("", selection: $date, in: range, displayedComponents: [.date])
                 .datePickerStyle(.graphical)
@@ -118,5 +118,14 @@ internal struct DatePickerPopover: View {
         .presentationDetents([.height(500)])
         .presentationDragIndicator(.visible)
         .frame(minWidth: 400, minHeight: 500)
+    }
+    
+    var body: some View {
+        if #available(iOS 16.4, *) {
+            innerBody
+                .presentationBackground(.regularMaterial)
+        } else {
+            innerBody
+        }
     }
 }

--- a/Sources/PennForms/FormComponents/DateField.swift
+++ b/Sources/PennForms/FormComponents/DateField.swift
@@ -3,8 +3,9 @@ import SwiftUI
 public struct DateField: FormComponent {
     
     @Binding var date: Date
-    @State var wasSet: Bool = false
+    @State var isPickerVisible = false
     @Environment(\.validator) var validator
+    @Environment(\.colorScheme) var colorScheme
     
     let range: ClosedRange<Date>?
     let title: String?
@@ -40,35 +41,39 @@ public struct DateField: FormComponent {
                 Text(title)
                     .bold()
             }
-            HStack {
-                Group {
-                    if date == .distantFuture {
-                        Text(placeholder ?? "")
-                            .foregroundStyle(.secondary)
-                        
-                    } else {
-                        Text(date, format: .dateTime.month(.twoDigits).day(.twoDigits).year())
-                    }
+            
+            Button {
+                if !isPickerVisible && date == .distantFuture {
+                    date = Date()
                 }
-                Spacer()
-                Image(systemName: "calendar")
-                    .font(.title3)
-                    .foregroundStyle(.blue)
-                    .overlay {
-                        DatePicker("", selection: $date, in: self.range ?? Date.distantPast...Date.distantFuture, displayedComponents: [.date])
-                            .onTapGesture {
-                                self.wasSet = true
-                            }
-                            .blendMode(.destinationOver)
+                
+                isPickerVisible.toggle()
+            } label: {
+                HStack {
+                    Group {
+                        if date == .distantFuture {
+                            Text(placeholder ?? "")
+                                .foregroundStyle(.secondary)
+                            
+                        } else {
+                            Text(date, format: .dateTime.month(.twoDigits).day(.twoDigits).year())
+                        }
                     }
+                    .tint(colorScheme == .dark ? .white : .black)
+
+                    Spacer()
+                    Image(systemName: "calendar")
+                        .font(.title3)
+                        .foregroundStyle(.tint)
+                }
+                .padding(.vertical, 15)
+                .padding(.horizontal, 10)
+                .cornerRadius(10)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(validator.isValid(date as AnyValidator.Input) ? Color.secondary.opacity(0.3): Color.red , lineWidth: 2)
+                )
             }
-            .padding(.vertical, 15)
-            .padding(.horizontal, 10)
-            .cornerRadius(10)
-            .overlay(
-                RoundedRectangle(cornerRadius: 8)
-                    .stroke(validator.isValid(date as AnyValidator.Input) ? Color.secondary.opacity(0.3): Color.red , lineWidth: 2)
-            )
             
             if !validator.isValid(date as AnyValidator.Input), let validatorMessage = validator.message {
                 HStack(spacing: 5) {
@@ -80,8 +85,24 @@ public struct DateField: FormComponent {
             }
         }
         .padding(.bottom, 5)
-        .onChange(of: wasSet) { _ in
-            self.date = .now
+        .popover(isPresented: $isPickerVisible) {
+            NavigationStack {
+                DatePicker("", selection: $date, in: self.range ?? Date.distantPast...Date.distantFuture, displayedComponents: [.date])
+                    .datePickerStyle(.graphical)
+                    .padding(.horizontal)
+                    .navigationTitle(title ?? "Select Date")
+                    .navigationBarTitleDisplayMode(.inline)
+                    .frame(maxHeight: .infinity, alignment: .top)
+                    .toolbar {
+                        ToolbarItem(placement: .primaryAction) {
+                            Button("Done") {
+                                isPickerVisible = false
+                            }
+                        }
+                    }
+            }
+            .presentationDetents([.medium])
+            .presentationDragIndicator(.visible)
         }
     }
 }

--- a/Sources/PennForms/FormComponents/DateField.swift
+++ b/Sources/PennForms/FormComponents/DateField.swift
@@ -86,23 +86,37 @@ public struct DateField: FormComponent {
         }
         .padding(.bottom, 5)
         .popover(isPresented: $isPickerVisible) {
-            NavigationStack {
-                DatePicker("", selection: $date, in: self.range ?? Date.distantPast...Date.distantFuture, displayedComponents: [.date])
-                    .datePickerStyle(.graphical)
-                    .padding(.horizontal)
-                    .navigationTitle(title ?? "Select Date")
-                    .navigationBarTitleDisplayMode(.inline)
-                    .frame(maxHeight: .infinity, alignment: .top)
-                    .toolbar {
-                        ToolbarItem(placement: .primaryAction) {
-                            Button("Done") {
-                                isPickerVisible = false
-                            }
+            DatePickerPopover(date: $date, range: self.range ?? Date.distantPast...Date.distantFuture, title: title)
+        }
+    }
+}
+
+internal struct DatePickerPopover: View {
+    @Binding var date: Date
+    var range: ClosedRange<Date>
+    var title: String?
+    
+    @Environment(\.dismiss) var dismiss
+    @Environment(\.verticalSizeClass) var sizeClass
+    
+    var body: some View {
+        NavigationStack {
+            DatePicker("", selection: $date, in: range, displayedComponents: [.date])
+                .datePickerStyle(.graphical)
+                .padding(.horizontal)
+                .navigationTitle(title ?? "Select Date")
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .primaryAction) {
+                        Button("Done") {
+                            dismiss()
                         }
                     }
-            }
-            .presentationDetents([.medium])
-            .presentationDragIndicator(.visible)
+                }
+                .frame(width: 400, height: 480, alignment: .top)
         }
+        .presentationDetents([.height(500)])
+        .presentationDragIndicator(.visible)
+        .frame(minWidth: 400, minHeight: 500)
     }
 }

--- a/Sources/PennForms/FormComponents/DateRangeField.swift
+++ b/Sources/PennForms/FormComponents/DateRangeField.swift
@@ -108,23 +108,7 @@ private struct DateRangeSubfield: View {
             )
         }
         .popover(isPresented: $isPickerVisible) {
-            NavigationStack {
-                DatePicker("", selection: $date, in: range, displayedComponents: [.date])
-                    .datePickerStyle(.graphical)
-                    .padding(.horizontal)
-                    .navigationTitle(placeholder ?? "Select Date")
-                    .navigationBarTitleDisplayMode(.inline)
-                    .frame(maxHeight: .infinity, alignment: .top)
-                    .toolbar {
-                        ToolbarItem(placement: .primaryAction) {
-                            Button("Done") {
-                                isPickerVisible = false
-                            }
-                        }
-                    }
-            }
-            .presentationDetents([.medium])
-            .presentationDragIndicator(.visible)
+            DatePickerPopover(date: $date, range: range, title: placeholder)
         }
     }
 }

--- a/Sources/PennForms/LabsForm.swift
+++ b/Sources/PennForms/LabsForm.swift
@@ -53,7 +53,7 @@ struct TestForm: View {
     }
     
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ScrollView {
                 LabsForm { formState in
                     TextLineField($name, placeholder: "Name")

--- a/Sources/PennForms/Validators/RequiredValidator.swift
+++ b/Sources/PennForms/Validators/RequiredValidator.swift
@@ -47,7 +47,7 @@ extension Decimal: HasEmpty {
 
 extension Date: HasEmpty {
     public var empty: Bool {
-        self == .distantFuture
+        self == .distantPast || self == .distantFuture
     }
 }
 


### PR DESCRIPTION
Makes date fields easier to activate by having them open sheets (popovers on iPadOS) when tapped.

<img width="401" alt="Example" src="https://github.com/pennlabs/PennForms/assets/7005789/c0d07395-817b-4185-a7e9-7ea2fcf39272">
