### PR TITLE
Disable hit testing on ImagePicker image

### DIFF
--- a/Sources/PennForms/FormComponents/ImagePicker.swift
+++ b/Sources/PennForms/FormComponents/ImagePicker.swift
@@ -43,7 +43,7 @@ public struct ImagePicker: FormComponent {
                                 .scaledToFill()
                                 .frame(width: 350, height: 200)
                                 .clipShape(RoundedRectangle(cornerRadius: 8))
-                                .contentShape(RoundedRectangle(cornerRadius: 8))
+                                .allowsHitTesting(false)
                                 
                         }
                     },
@@ -63,6 +63,7 @@ public struct ImagePicker: FormComponent {
                                 .frame(width: 350, height: 200)
                                 .clipShape(RoundedRectangle(cornerRadius: 8))
                                 .contentShape(RoundedRectangle(cornerRadius: 8))
+                                .allowsHitTesting(false)
                                 
                         
                     }

--- a/Sources/PennForms/FormComponents/ImagePicker.swift
+++ b/Sources/PennForms/FormComponents/ImagePicker.swift
@@ -40,7 +40,7 @@ public struct ImagePicker: FormComponent {
                             
                             image
                                 .resizable()
-                                .aspectRatio(contentMode: .fill)
+                                .scaledToFill()
                                 .frame(width: 350, height: 200)
                                 .clipShape(RoundedRectangle(cornerRadius: 8))
                                 
@@ -58,7 +58,7 @@ public struct ImagePicker: FormComponent {
                             
                     Image(uiImage: selectedImages[0])
                                 .resizable()
-                                .aspectRatio(contentMode: .fill)
+                                .scaledToFill()
                                 .frame(width: 350, height: 200)
                                 .clipShape(RoundedRectangle(cornerRadius: 8))
                                 

--- a/Sources/PennForms/FormComponents/ImagePicker.swift
+++ b/Sources/PennForms/FormComponents/ImagePicker.swift
@@ -43,6 +43,7 @@ public struct ImagePicker: FormComponent {
                                 .scaledToFill()
                                 .frame(width: 350, height: 200)
                                 .clipShape(RoundedRectangle(cornerRadius: 8))
+                                .contentShape(RoundedRectangle(cornerRadius: 8)
                                 
                         }
                     },
@@ -61,6 +62,7 @@ public struct ImagePicker: FormComponent {
                                 .scaledToFill()
                                 .frame(width: 350, height: 200)
                                 .clipShape(RoundedRectangle(cornerRadius: 8))
+                                .contentShape(RoundedRectangle(cornerRadius: 8)
                                 
                         
                     }

--- a/Sources/PennForms/FormComponents/ImagePicker.swift
+++ b/Sources/PennForms/FormComponents/ImagePicker.swift
@@ -43,7 +43,7 @@ public struct ImagePicker: FormComponent {
                                 .scaledToFill()
                                 .frame(width: 350, height: 200)
                                 .clipShape(RoundedRectangle(cornerRadius: 8))
-                                .contentShape(RoundedRectangle(cornerRadius: 8)
+                                .contentShape(RoundedRectangle(cornerRadius: 8))
                                 
                         }
                     },
@@ -62,7 +62,7 @@ public struct ImagePicker: FormComponent {
                                 .scaledToFill()
                                 .frame(width: 350, height: 200)
                                 .clipShape(RoundedRectangle(cornerRadius: 8))
-                                .contentShape(RoundedRectangle(cornerRadius: 8)
+                                .contentShape(RoundedRectangle(cornerRadius: 8))
                                 
                         
                     }


### PR DESCRIPTION
Ensures that the image doesn't steal taps from adjacent fields (e.g. the Listing Name field on the subletting form.)

If in the future we need to have an action occur when the user taps a large image, we can set a tap handler on either the backing rectangle or the `ZStack` itself.
