### PR TITLE
Add environment value for suppressing validation errors

### DIFF
--- a/Sources/PennForms/FormComponents/ComponentsFieldStyle.swift
+++ b/Sources/PennForms/FormComponents/ComponentsFieldStyle.swift
@@ -1,17 +1,34 @@
 import SwiftUI
 
-public extension View {
-    func componentFormStyle(isValid: Bool, validatorMessage: String? = nil) -> some View {
-        VStack(alignment: .leading) {
-            self
+struct ShowValidationErrorsKey: EnvironmentKey {
+    static let defaultValue = true
+}
+
+public extension EnvironmentValues {
+    var showValidationErrors: Bool {
+        get { self[ShowValidationErrorsKey.self] }
+        set { self[ShowValidationErrorsKey.self] = newValue }
+    }
+}
+
+struct ComponentFormStyleModifier: ViewModifier {
+    @Environment(\.showValidationErrors) var showValidationErrors
+    var isValid: Bool
+    var validatorMessage: String?
+    
+    func body(content: Content) -> some View {
+        let isError = showValidationErrors && !isValid
+        
+        return VStack(alignment: .leading) {
+            content
                 .padding(.vertical, 15) // Adds space inside the text field
                 .padding(.horizontal, 10)
                 .cornerRadius(10) // Makes the corners rounded
                 .overlay(
                     RoundedRectangle(cornerRadius: 8)
-                        .stroke(isValid ? Color.secondary.opacity(0.3): Color.red , lineWidth: 2)
+                        .stroke(isError ? Color.red : Color.secondary.opacity(0.3), lineWidth: 2)
                 )
-            if !isValid, let validatorMessage {
+            if isError, let validatorMessage {
                 HStack(spacing: 5) {
                     Image(systemName: "exclamationmark.circle")
                     Text(validatorMessage)
@@ -21,5 +38,11 @@ public extension View {
             }
         }
         .padding(.bottom, 5)
+    }
+}
+
+public extension View {
+    func componentFormStyle(isValid: Bool, validatorMessage: String? = nil) -> some View {
+        modifier(ComponentFormStyleModifier(isValid: isValid, validatorMessage: validatorMessage))
     }
 }

--- a/Sources/PennForms/FormComponents/DateField.swift
+++ b/Sources/PennForms/FormComponents/DateField.swift
@@ -6,6 +6,7 @@ public struct DateField: FormComponent {
     @State var isPickerVisible = false
     @Environment(\.validator) var validator
     @Environment(\.colorScheme) var colorScheme
+    @Environment(\.showValidationErrors) var showValidationErrors
     
     let range: ClosedRange<Date>?
     let title: String?
@@ -71,11 +72,11 @@ public struct DateField: FormComponent {
                 .cornerRadius(10)
                 .overlay(
                     RoundedRectangle(cornerRadius: 8)
-                        .stroke(validator.isValid(date as AnyValidator.Input) ? Color.secondary.opacity(0.3): Color.red , lineWidth: 2)
+                        .stroke(!showValidationErrors || validator.isValid(date as AnyValidator.Input) ? Color.secondary.opacity(0.3): Color.red , lineWidth: 2)
                 )
             }
             
-            if !validator.isValid(date as AnyValidator.Input), let validatorMessage = validator.message {
+            if showValidationErrors, !validator.isValid(date as AnyValidator.Input), let validatorMessage = validator.message {
                 HStack(spacing: 5) {
                     Image(systemName: "exclamationmark.circle")
                     Text(validatorMessage)

--- a/Sources/PennForms/FormComponents/DateRangeField.swift
+++ b/Sources/PennForms/FormComponents/DateRangeField.swift
@@ -6,6 +6,7 @@ public struct DateRangeField: FormComponent {
     @Binding var upperDate: Date
     @State var wasSet: Bool = false
     @Environment(\.validator) var validator
+    @Environment(\.showValidationErrors) var showValidationErrors
     
     let range: ClosedRange<Date>
     let upperOffset: Int
@@ -51,7 +52,7 @@ public struct DateRangeField: FormComponent {
                 DateRangeSubfield(date: $upperDate, range: lowerDate...self.range.upperBound, placeholder: upperPlaceholder, wasSet: $wasSet)
             }
             
-            if !validator.isValid(lowerDate as AnyValidator.Input) || !validator.isValid(upperDate as AnyValidator.Input), let validatorMessage = validator.message {
+            if showValidationErrors, !validator.isValid(lowerDate as AnyValidator.Input) || !validator.isValid(upperDate as AnyValidator.Input), let validatorMessage = validator.message {
                 HStack(spacing: 5) {
                     Image(systemName: "exclamationmark.circle")
                     Text(validatorMessage)
@@ -76,6 +77,7 @@ private struct DateRangeSubfield: View {
     
     @Environment(\.validator) var validator
     @Environment(\.colorScheme) var colorScheme
+    @Environment(\.showValidationErrors) var showValidationErrors
     @State var isPickerVisible = false
     
     var body: some View {
@@ -104,7 +106,7 @@ private struct DateRangeSubfield: View {
             .cornerRadius(10)
             .overlay(
                 RoundedRectangle(cornerRadius: 8)
-                    .stroke(validator.isValid(date as AnyValidator.Input) ? Color.secondary.opacity(0.3): Color.red , lineWidth: 2)
+                    .stroke(!showValidationErrors || validator.isValid(date as AnyValidator.Input) ? Color.secondary.opacity(0.3): Color.red , lineWidth: 2)
             )
         }
         .popover(isPresented: $isPickerVisible) {

--- a/Sources/PennForms/FormComponents/ImagePicker.swift
+++ b/Sources/PennForms/FormComponents/ImagePicker.swift
@@ -10,6 +10,7 @@ import PhotosUI
 
 public struct ImagePicker: FormComponent {
     @Environment(\.validator) var validator
+    @Environment(\.showValidationErrors) var showValidationErrors
     @State var selection: [PhotosPickerItem]
     @Binding var selectedImages: [UIImage]
     @Binding var existingImages: [String]
@@ -75,7 +76,7 @@ public struct ImagePicker: FormComponent {
                     .frame(width: 350, height: 200)
                     .background(RoundedRectangle(cornerRadius: 8)
                         .strokeBorder(style: StrokeStyle(lineWidth: 1, dash: [7])))
-                    .foregroundColor(validator.isValid(selectedImages.count + existingImages.count) ? Color.secondary : Color.red)
+                    .foregroundColor(!showValidationErrors || validator.isValid(selectedImages.count + existingImages.count) ? Color.secondary : Color.red)
                 }
                              .onChange(of: selection) { newSelection in
                                  Task {
@@ -158,7 +159,7 @@ public struct ImagePicker: FormComponent {
                 }
             }
             
-            if !validator.isValid(selectedImages.count + existingImages.count), let validatorMessage = validator.message {
+            if showValidationErrors, !validator.isValid(selectedImages.count + existingImages.count), let validatorMessage = validator.message {
                 HStack(spacing: 5) {
                     Image(systemName: "exclamationmark.circle")
                     Text(validatorMessage)

--- a/Sources/PennForms/FormComponents/OptionField.swift
+++ b/Sources/PennForms/FormComponents/OptionField.swift
@@ -8,6 +8,7 @@ public struct OptionField<Option: Hashable>: FormComponent {
     let placeholder: String?
     
     @Environment(\.validator) var validator
+    @Environment(\.showValidationErrors) var showValidationErrors
     
     public init(_ selection: Binding<Option?>, options: [Option], toString: @escaping (Option) -> String, title: String? = nil, placeholder: String? = nil) {
         self._selection = selection
@@ -50,7 +51,7 @@ public struct OptionField<Option: Hashable>: FormComponent {
             .customPickerStyle(
                 labelText: selection == nil ? nil : toString(selection!), placeholder: placeholder, width: 200, isValid: validator.isValid(selection as AnyValidator.Input)
             )
-            if !validator.isValid(selection as AnyValidator.Input), let message = validator.message {
+            if showValidationErrors, !validator.isValid(selection as AnyValidator.Input), let message = validator.message {
                 HStack(spacing: 5) {
                     Image(systemName: "exclamationmark.circle")
                     Text(message)
@@ -67,6 +68,8 @@ struct CustomPickerStyle: ViewModifier {
     let placeholder: String?
     var width: CGFloat
     let isValid: Bool
+    
+    @Environment(\.showValidationErrors) var showValidationErrors
     
     func body(content: Content) -> some View {
         Menu {
@@ -88,7 +91,7 @@ struct CustomPickerStyle: ViewModifier {
         .background(.background)
         .overlay(
             RoundedRectangle(cornerRadius: 8)
-                .stroke(isValid ? Color.secondary.opacity(0.3): Color.red , lineWidth: 2)
+                .stroke(isValid || !showValidationErrors ? Color.secondary.opacity(0.3): Color.red , lineWidth: 2)
         )
     }
 }

--- a/Sources/PennForms/FormComponents/TagSelector.swift
+++ b/Sources/PennForms/FormComponents/TagSelector.swift
@@ -10,6 +10,7 @@ public struct TagSelector<Tag: Hashable>: FormComponent {
     
     @Environment(\.validator) var validator
     @Environment(\.colorScheme) var colorScheme
+    @Environment(\.showValidationErrors) var showValidationErrors
     
     public enum Customisable {
         case notCustomisable
@@ -69,7 +70,7 @@ public struct TagSelector<Tag: Hashable>: FormComponent {
                     .buttonStyle(.plain)
                 }
             
-            if !validator.isValid(selection as AnyValidator.Input), let message = validator.message {
+            if showValidationErrors, !validator.isValid(selection as AnyValidator.Input), let message = validator.message {
                 HStack(spacing: 5) {
                     Image(systemName: "exclamationmark.circle")
                     Text(message)

--- a/Sources/PennForms/FormComponents/TextAreaField.swift
+++ b/Sources/PennForms/FormComponents/TextAreaField.swift
@@ -7,6 +7,7 @@ public struct TextAreaField: FormComponent {
     let characterCount: Int?
     
     @Environment(\.validator) var validator
+    @Environment(\.showValidationErrors) var showValidationErrors
     
     public init(_ text: Binding<String>, characterCount: Int? = nil, title: String? = nil) {
         self._text = text
@@ -44,12 +45,12 @@ public struct TextAreaField: FormComponent {
                 .cornerRadius(10) // Makes the corners rounded
                 .overlay {
                     RoundedRectangle(cornerRadius: 8)
-                        .stroke(validator.isValid(text) ? Color.secondary.opacity(0.3): Color.red , lineWidth: 2)
+                        .stroke(!showValidationErrors || validator.isValid(text) ? Color.secondary.opacity(0.3): Color.red , lineWidth: 2)
                 }
             
             HStack(spacing: 5) {
                 Group {
-                    if !validator.isValid(text), let validatorMessage = validator.message {
+                    if showValidationErrors, !validator.isValid(text), let validatorMessage = validator.message {
                         Image(systemName: "exclamationmark.circle")
                         Text(validatorMessage)
                     }

--- a/Sources/PennForms/LabsForm.swift
+++ b/Sources/PennForms/LabsForm.swift
@@ -47,6 +47,8 @@ struct TestForm: View {
     
     @State private var amenities: OrderedSet = ["Gym", "Private bathroom", "asd", "asdas", "qweuh"]
     
+    @State var showValidationErrors = false
+    
     var dateRange: ClosedRange<Date> {
         let upper = Calendar.current.date(byAdding: .init(day: 5), to: .now)!
         return .now...upper
@@ -100,7 +102,9 @@ struct TestForm: View {
                         .validator(.required)
                     
                     ComponentWrapper {
-                        Button(action: {}) {
+                        Button(action: {
+                            showValidationErrors = true
+                        }) {
                             Text("Submit")
                                 .font(.title3)
                                 .bold()
@@ -115,6 +119,7 @@ struct TestForm: View {
                         .disabled(!formState.isValid)
                     }
                 }
+                .environment(\.showValidationErrors, showValidationErrors)
             }
             .navigationTitle("Info form")
         }


### PR DESCRIPTION
Helps us support use cases like showing validation errors only after a submission attempt is made.
