### PR TITLE
Update version checking for maximal compatability

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/siteline/swiftui-introspect.git",
       "state" : {
-        "revision" : "9e1cc02a65b22e09a8251261cccbccce02731fc5",
-        "version" : "1.1.1"
+        "revision" : "807f73ce09a9b9723f12385e592b4e0aaebd3336",
+        "version" : "1.3.0"
       }
     }
   ],

--- a/Sources/PennForms/FormComponents/NumericField.swift
+++ b/Sources/PennForms/FormComponents/NumericField.swift
@@ -1,4 +1,4 @@
-import SwiftUIIntrospect
+@_spi(Advanced) import SwiftUIIntrospect
 import SwiftUI
 
 public struct NumericField<FormatStyle: ParseableFormatStyle>: FormComponent where FormatStyle.FormatInput == Decimal, FormatStyle.FormatOutput == String {
@@ -76,7 +76,7 @@ public struct NumericField<FormatStyle: ParseableFormatStyle>: FormComponent whe
             }
             
             TextField(placeholder ?? " ", value: $value, format: format)
-                .introspect(.textField, on: .iOS(.v16, .v17), customize: { textField in
+                .introspect(.textField, on: .iOS(.v16...), customize: { textField in
                     if self.value == .nan {
                         textField.text = placeholder
                     }

--- a/Sources/PennForms/FormComponents/TextAreaField.swift
+++ b/Sources/PennForms/FormComponents/TextAreaField.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+@_spi(Advanced) import SwiftUIIntrospect
 
 public struct TextAreaField: FormComponent {
     @Binding var text: String
@@ -36,7 +37,7 @@ public struct TextAreaField: FormComponent {
                     .bold()
             }
             TextEditor(text: $text)
-                .introspect(.textEditor, on: .iOS(.v16), .iOS(.v17)) { textEditor in
+                .introspect(.textEditor, on: .iOS(.v16...)) { textEditor in
                     if textEditor.text == "∞" {
                         self.text = ""
                     }

--- a/Sources/PennForms/FormComponents/TextLineField.swift
+++ b/Sources/PennForms/FormComponents/TextLineField.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+@_spi(Advanced) import SwiftUIIntrospect
 
 public struct TextLineField: FormComponent {
     @Binding var text: String
@@ -33,7 +34,7 @@ public struct TextLineField: FormComponent {
                     .bold()
             }
             TextField(placeholder ?? "", text: $text)
-                .introspect(.textField, on: .iOS(.v16), .iOS(.v17)) { textField in
+                .introspect(.textField, on: .iOS(.v16...)) { textField in
                     if textField.text == "∞" {
                         textField.text = ""
                     }


### PR DESCRIPTION
Per the [README.md for swiftui-introspect](https://github.com/siteline/swiftui-introspect#introspect-on-future-platform-versions):

"By default, introspection applies per specific platform version. This is a sensible default for maximum predictability in regularly maintained codebases, but it's not always a good fit for e.g. library developers who may want to cover as many future platform versions as possible in order to provide the best chance for long-term future functionality of their library without regular maintenance."

This change has been made and is dependent on Swift not changing the behavior of SwiftUI under-the-hood in the future. The upside to this is that we (Penn Labs) do not have to be constantly updating the introspect versions in the future with updates to iOS.

