### PR TITLE
Rewrite message system (to fix ManyValidator)

### DIFF
--- a/Sources/PennForms/FormBuilder.swift
+++ b/Sources/PennForms/FormBuilder.swift
@@ -3,7 +3,7 @@ public struct FormBuilder {
     public static func buildPartialBlock<Content: FormComponent>(first: Content) -> Content {
         first
     }
-    
+
     public static func buildPartialBlock<C0: FormComponent, C1: FormComponent>(accumulated: C0, next: C1) -> _SequenceFormComponent<C0, C1> {
         return _SequenceFormComponent(c0: accumulated, c1: next)
     }

--- a/Sources/PennForms/FormComponent.swift
+++ b/Sources/PennForms/FormComponent.swift
@@ -5,7 +5,7 @@ public protocol FormComponent: View {}
 public struct _SequenceFormComponent<C0: FormComponent, C1: FormComponent>: FormComponent {
     let c0: C0
     let c1: C1
-    
+
     public var body: some View {
         VStack(alignment: .leading) {
             c0
@@ -16,7 +16,7 @@ public struct _SequenceFormComponent<C0: FormComponent, C1: FormComponent>: Form
 
 public struct ComponentWrapper<Content: View>: FormComponent {
     @ViewBuilder let content: () -> Content
-    
+
     public init(content: @escaping () -> Content) {
         self.content = content
     }

--- a/Sources/PennForms/FormComponents/ComponentsFieldStyle.swift
+++ b/Sources/PennForms/FormComponents/ComponentsFieldStyle.swift
@@ -15,10 +15,10 @@ struct ComponentFormStyleModifier: ViewModifier {
     @Environment(\.showValidationErrors) var showValidationErrors
     var isValid: Bool
     var validatorMessage: String?
-    
+
     func body(content: Content) -> some View {
         let isError = showValidationErrors && !isValid
-        
+
         return VStack(alignment: .leading) {
             content
                 .padding(.vertical, 15) // Adds space inside the text field

--- a/Sources/PennForms/FormComponents/DateField.swift
+++ b/Sources/PennForms/FormComponents/DateField.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 public struct DateField: FormComponent {
-
     @Binding var date: Date
     @State var isPickerVisible = false
     @Environment(\.validator) var validator

--- a/Sources/PennForms/FormComponents/DateField.swift
+++ b/Sources/PennForms/FormComponents/DateField.swift
@@ -76,7 +76,7 @@ public struct DateField: FormComponent {
                 )
             }
             
-            if showValidationErrors, !validator.isValid(date as AnyValidator.Input), let validatorMessage = validator.message {
+            if showValidationErrors, !validator.isValid(date as AnyValidator.Input), let validatorMessage = validator.message(date as AnyValidator.Input) {
                 HStack(spacing: 5) {
                     Image(systemName: "exclamationmark.circle")
                     Text(validatorMessage)

--- a/Sources/PennForms/FormComponents/DateField.swift
+++ b/Sources/PennForms/FormComponents/DateField.swift
@@ -1,17 +1,17 @@
 import SwiftUI
 
 public struct DateField: FormComponent {
-    
+
     @Binding var date: Date
     @State var isPickerVisible = false
     @Environment(\.validator) var validator
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.showValidationErrors) var showValidationErrors
-    
+
     let range: ClosedRange<Date>?
     let title: String?
     let placeholder: String?
-    
+
     public init(date: Binding<Date?>, in range: ClosedRange<Date>? = nil, title: String? = nil, placeholder: String? = nil) {
         self._date = Binding(
             get: {
@@ -27,7 +27,7 @@ public struct DateField: FormComponent {
         self.placeholder = placeholder
         self._validator = Environment(\.validator)
     }
-    
+
     public init(date: Binding<Date>, in range: ClosedRange<Date>? = nil, title: String? = nil, placeholder: String? = nil) {
         self._date = date
         self.range = range
@@ -35,19 +35,19 @@ public struct DateField: FormComponent {
         self.placeholder = placeholder
         self._validator = Environment(\.validator)
     }
-    
+
     public var body: some View {
         VStack(alignment: .leading) {
             if let title {
                 Text(title)
                     .bold()
             }
-            
+
             Button {
                 if !isPickerVisible && date == .distantFuture {
                     date = Date()
                 }
-                
+
                 isPickerVisible.toggle()
             } label: {
                 HStack {
@@ -55,7 +55,7 @@ public struct DateField: FormComponent {
                         if date == .distantFuture {
                             Text(placeholder ?? "")
                                 .foregroundStyle(.secondary)
-                            
+
                         } else {
                             Text(date, format: .dateTime.month(.twoDigits).day(.twoDigits).year())
                         }
@@ -72,10 +72,10 @@ public struct DateField: FormComponent {
                 .cornerRadius(10)
                 .overlay(
                     RoundedRectangle(cornerRadius: 8)
-                        .stroke(!showValidationErrors || validator.isValid(date as AnyValidator.Input) ? Color.secondary.opacity(0.3): Color.red , lineWidth: 2)
+                        .stroke(!showValidationErrors || validator.isValid(date as AnyValidator.Input) ? Color.secondary.opacity(0.3): Color.red, lineWidth: 2)
                 )
             }
-            
+
             if showValidationErrors, !validator.isValid(date as AnyValidator.Input), let validatorMessage = validator.message(date as AnyValidator.Input) {
                 HStack(spacing: 5) {
                     Image(systemName: "exclamationmark.circle")
@@ -96,17 +96,17 @@ internal struct DatePickerPopover: View {
     @Binding var date: Date
     var range: ClosedRange<Date>
     var title: String?
-    
+
     @Environment(\.dismiss) var dismiss
     @Environment(\.verticalSizeClass) var sizeClass
-    
+
     var innerBody: some View {
         NavigationStack {
             ScrollView {
                 VStack(spacing: 0) {
                     DatePicker("", selection: $date, in: range, displayedComponents: [.date])
                         .datePickerStyle(.graphical)
-                    
+
                     Button("Select") {
                         dismiss()
                     }
@@ -123,7 +123,7 @@ internal struct DatePickerPopover: View {
         .presentationDragIndicator(.visible)
         .frame(minWidth: 400, minHeight: 500)
     }
-    
+
     var body: some View {
         if #available(iOS 16.4, *) {
             innerBody

--- a/Sources/PennForms/FormComponents/DateRangeField.swift
+++ b/Sources/PennForms/FormComponents/DateRangeField.swift
@@ -1,20 +1,20 @@
 import SwiftUI
 
 public struct DateRangeField: FormComponent {
-    
+
     @Binding var lowerDate: Date
     @Binding var upperDate: Date
     @State var wasSet1: Bool = false
     @State var wasSet2: Bool = false
     @Environment(\.validator) var validator
     @Environment(\.showValidationErrors) var showValidationErrors
-    
+
     let range: ClosedRange<Date>
     let upperOffset: Int
     let title: String?
     let lowerPlaceholder: String?
     let upperPlaceholder: String?
-    
+
     public init(lowerDate: Binding<Date?>, upperDate: Binding<Date?>, in range: ClosedRange<Date>? = nil, upperOffset: Int = 0, title: String? = nil, lowerPlaceholder: String? = nil, upperPlaceholder: String? = nil) {
         self._lowerDate = Binding(
             get: {
@@ -41,7 +41,7 @@ public struct DateRangeField: FormComponent {
         self.upperPlaceholder = upperPlaceholder
         self._validator = Environment(\.validator)
     }
-    
+
     public var body: some View {
         VStack(alignment: .leading) {
             if let title {
@@ -56,7 +56,7 @@ public struct DateRangeField: FormComponent {
                 DateRangeSubfield(date: $lowerDate, range: self.range.lowerBound...validEnd, placeholder: lowerPlaceholder, wasSet: $wasSet1)
                 DateRangeSubfield(date: $upperDate, range: validBegin...self.range.upperBound, placeholder: upperPlaceholder, wasSet: $wasSet2)
             }
-            
+
             if showValidationErrors, !validator.isValid(lowerDate as AnyValidator.Input) || !validator.isValid(upperDate as AnyValidator.Input), let validatorMessage = validator.message(lowerDate as AnyValidator.Input) ?? validator.message(upperDate as AnyValidator.Input) {
                 HStack(spacing: 5) {
                     Image(systemName: "exclamationmark.circle")
@@ -81,12 +81,12 @@ private struct DateRangeSubfield: View {
     var range: ClosedRange<Date>
     var placeholder: String?
     @Binding var wasSet: Bool
-    
+
     @Environment(\.validator) var validator
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.showValidationErrors) var showValidationErrors
     @State var isPickerVisible = false
-    
+
     var body: some View {
         Button {
             isPickerVisible.toggle()
@@ -102,7 +102,7 @@ private struct DateRangeSubfield: View {
                     }
                 }
                 .tint(colorScheme == .dark ? .white : .black)
-                
+
                 Spacer()
                 Image(systemName: "calendar")
                     .font(.title3)
@@ -113,7 +113,7 @@ private struct DateRangeSubfield: View {
             .cornerRadius(10)
             .overlay(
                 RoundedRectangle(cornerRadius: 8)
-                    .stroke(!showValidationErrors || validator.isValid(date as AnyValidator.Input) ? Color.secondary.opacity(0.3): Color.red , lineWidth: 2)
+                    .stroke(!showValidationErrors || validator.isValid(date as AnyValidator.Input) ? Color.secondary.opacity(0.3): Color.red, lineWidth: 2)
             )
         }
         .popover(isPresented: $isPickerVisible) {

--- a/Sources/PennForms/FormComponents/DateRangeField.swift
+++ b/Sources/PennForms/FormComponents/DateRangeField.swift
@@ -49,13 +49,15 @@ public struct DateRangeField: FormComponent {
                     .bold()
             }
             HStack {
-                let begin = range.lowerBound < lowerDate ? lowerDate : range.lowerBound
-                let end = range.upperBound > upperDate ? upperDate : range.upperBound
-                DateRangeSubfield(date: $lowerDate, range: self.range.lowerBound...end, placeholder: lowerPlaceholder, wasSet: $wasSet1)
-                DateRangeSubfield(date: $upperDate, range: begin...self.range.upperBound, placeholder: upperPlaceholder, wasSet: $wasSet2)
+                let begin = max(lowerDate, range.lowerBound)
+                let end = min(upperDate, range.upperBound)
+                let validBegin = min(range.upperBound, begin)
+                let validEnd = max(range.lowerBound, end)
+                DateRangeSubfield(date: $lowerDate, range: self.range.lowerBound...validEnd, placeholder: lowerPlaceholder, wasSet: $wasSet1)
+                DateRangeSubfield(date: $upperDate, range: validBegin...self.range.upperBound, placeholder: upperPlaceholder, wasSet: $wasSet2)
             }
             
-            if showValidationErrors, !validator.isValid(lowerDate as AnyValidator.Input) || !validator.isValid(upperDate as AnyValidator.Input), let validatorMessage = validator.message {
+            if showValidationErrors, !validator.isValid(lowerDate as AnyValidator.Input) || !validator.isValid(upperDate as AnyValidator.Input), let validatorMessage = validator.message(lowerDate as AnyValidator.Input) ?? validator.message(upperDate as AnyValidator.Input) {
                 HStack(spacing: 5) {
                     Image(systemName: "exclamationmark.circle")
                     Text(validatorMessage)

--- a/Sources/PennForms/FormComponents/DateRangeField.swift
+++ b/Sources/PennForms/FormComponents/DateRangeField.swift
@@ -1,7 +1,6 @@
 import SwiftUI
 
 public struct DateRangeField: FormComponent {
-
     @Binding var lowerDate: Date
     @Binding var upperDate: Date
     @State var wasSet1: Bool = false
@@ -49,21 +48,26 @@ public struct DateRangeField: FormComponent {
                     .bold()
             }
             HStack {
-                let begin = max(lowerDate, range.lowerBound)
-                let end = min(upperDate, range.upperBound)
-                let validBegin = min(range.upperBound, begin)
-                let validEnd = max(range.lowerBound, end)
-                DateRangeSubfield(date: $lowerDate, range: self.range.lowerBound...validEnd, placeholder: lowerPlaceholder, wasSet: $wasSet1)
-                DateRangeSubfield(date: $upperDate, range: validBegin...self.range.upperBound, placeholder: upperPlaceholder, wasSet: $wasSet2)
+                DateRangeSubfield(date: $lowerDate, range: self.range, placeholder: lowerPlaceholder, wasSet: $wasSet1)
+                DateRangeSubfield(date: $upperDate, range: self.range, placeholder: upperPlaceholder, wasSet: $wasSet2)
             }
 
-            if showValidationErrors, !validator.isValid(lowerDate as AnyValidator.Input) || !validator.isValid(upperDate as AnyValidator.Input), let validatorMessage = validator.message(lowerDate as AnyValidator.Input) ?? validator.message(upperDate as AnyValidator.Input) {
-                HStack(spacing: 5) {
-                    Image(systemName: "exclamationmark.circle")
-                    Text(validatorMessage)
+            if showValidationErrors {
+                if !validator.isValid(lowerDate as AnyValidator.Input) || !validator.isValid(upperDate as AnyValidator.Input), let validatorMessage = validator.message(lowerDate as AnyValidator.Input) ?? validator.message(upperDate as AnyValidator.Input) {
+                    HStack(spacing: 5) {
+                        Image(systemName: "exclamationmark.circle")
+                        Text(validatorMessage)
+                    }
+                    .foregroundColor(.red)
+                    .preference(key: ValidPreferenceKey.self, value: false)
+                } else if lowerDate > upperDate {
+                    HStack(spacing: 5) {
+                        Image(systemName: "exclamationmark.circle")
+                        Text("Start date must be before end date")
+                    }
+                    .foregroundColor(.red)
+                    .preference(key: ValidPreferenceKey.self, value: false)
                 }
-                .foregroundColor(.red)
-                .preference(key: ValidPreferenceKey.self, value: false)
             }
         }
         .padding(.bottom, 5)

--- a/Sources/PennForms/FormComponents/FormGroup.swift
+++ b/Sources/PennForms/FormComponents/FormGroup.swift
@@ -35,7 +35,7 @@ public extension FormGroup {
                      .validator(AnyValidator { false })
                     HStack(spacing: 5) {
                         Image(systemName: "exclamationmark.circle")
-                        Text(validator.message ?? "Enter a valid input")
+                        Text(validator.message(nil) ?? "Enter a valid input")
                     }
                     .foregroundColor(.red)
                 } else {

--- a/Sources/PennForms/FormComponents/FormGroup.swift
+++ b/Sources/PennForms/FormComponents/FormGroup.swift
@@ -4,17 +4,17 @@ public struct FormGroup<Content: FormComponent>: FormComponent {
     let title: String?
     @FormBuilder let content: () -> Content
     @Environment(\.validator) private var validator
-    
+
     public init(title: String, @FormBuilder content: @escaping () -> Content) {
         self.title = title
         self.content = content
     }
-    
+
     public init(@FormBuilder content: @escaping () -> Content) {
         self.title = nil
         self.content = content
     }
-    
+
     public var body: some View {
         VStack(alignment: .leading) {
             if let title {

--- a/Sources/PennForms/FormComponents/ImagePicker.swift
+++ b/Sources/PennForms/FormComponents/ImagePicker.swift
@@ -165,7 +165,7 @@ public struct ImagePicker: FormComponent {
                 }
             }
             
-            if showValidationErrors, !validator.isValid(selectedImages.count + existingImages.count), let validatorMessage = validator.message {
+            if showValidationErrors, !validator.isValid(selectedImages.count + existingImages.count), let validatorMessage = validator.message(selectedImages.count + existingImages.count) {
                 HStack(spacing: 5) {
                     Image(systemName: "exclamationmark.circle")
                     Text(validatorMessage)

--- a/Sources/PennForms/FormComponents/ImagePicker.swift
+++ b/Sources/PennForms/FormComponents/ImagePicker.swift
@@ -15,7 +15,7 @@ public struct ImagePicker: FormComponent {
     @Binding var selectedImages: [UIImage]
     @Binding var existingImages: [String]
     let maxSelectionCount: Int
-    
+
     public init(_ selectedImages: Binding<[UIImage]>, existingImages: Binding<[String]>? = nil as Binding<[String]>?, maxSelectionCount: Int = 5) {
         self.selection = []
         self._selectedImages = selectedImages
@@ -27,7 +27,7 @@ public struct ImagePicker: FormComponent {
         self.maxSelectionCount = maxSelectionCount
         self._validator = Environment(\.validator)
     }
-    
+
     public var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             if existingImages.count > 0 {
@@ -39,13 +39,13 @@ public struct ImagePicker: FormComponent {
                             RoundedRectangle(cornerRadius: 8)
                                 .strokeBorder(style: StrokeStyle(lineWidth: 0.5))
                                 .frame(width: 350, height: 200)
-                            
+
                             image
                                 .resizable()
                                 .aspectRatio(contentMode: .fill)
                                 .frame(width: 350, height: 200)
                                 .clipShape(RoundedRectangle(cornerRadius: 8))
-                                
+
                         }
                     },
                     placeholder: {
@@ -58,14 +58,13 @@ public struct ImagePicker: FormComponent {
                             RoundedRectangle(cornerRadius: 8)
                                 .strokeBorder(style: StrokeStyle(lineWidth: 0.5))
                                 .frame(width: 350, height: 200)
-                            
+
                     Image(uiImage: selectedImages[0])
                                 .resizable()
                                 .aspectRatio(contentMode: .fill)
                                 .frame(width: 350, height: 200)
                                 .clipShape(RoundedRectangle(cornerRadius: 8))
-                                
-                        
+
                     }
             } else {
                 // else it displays the red "Add Photos" in the big photo frame
@@ -92,8 +91,7 @@ public struct ImagePicker: FormComponent {
                                  }
                              }
             }
-            
-            
+
             ScrollView(.horizontal) {
                 HStack(spacing: 8) {
                     ForEach(Array(existingImages.enumerated()), id: \.offset) { index, image in
@@ -119,7 +117,7 @@ public struct ImagePicker: FormComponent {
                             }
                         }
                     }
-                    if (existingImages.count == 0 && selectedImages.count-1 > 0) || selectedImages.count > 0  {
+                    if (existingImages.count == 0 && selectedImages.count-1 > 0) || selectedImages.count > 0 {
                         // if there were no existing images and there are a number of selected images, then this displays the rest of the selected images from index 1. else if there were existing images then the first big photo frame is already filled and we start the selected images at count 0.
                         ForEach(Array(selectedImages.enumerated()), id: \.offset) { index, image in
                             if index != 0 {
@@ -127,7 +125,7 @@ public struct ImagePicker: FormComponent {
                                     RoundedRectangle(cornerRadius: 8)
                                         .strokeBorder(style: StrokeStyle(lineWidth: 0.5))
                                         .frame(width: 120, height: 120)
-                                    
+
                                     Image(uiImage: image)
                                         .resizable()
                                         .aspectRatio(contentMode: .fill)
@@ -136,7 +134,7 @@ public struct ImagePicker: FormComponent {
                                 }
                             }
                         }
-                    
+
                     }
                     if selectedImages.count + existingImages.count < maxSelectionCount {
                         // if there are still spaces left for images to be added, we show the add image small icon boxes
@@ -144,7 +142,7 @@ public struct ImagePicker: FormComponent {
                             PhotosPicker(selection: $selection,
                                          maxSelectionCount: maxSelectionCount - existingImages.count,
                                          matching: .any(of: [.images, .not(.videos)])) {
- 
+
                                     Image(systemName: "photo.badge.plus")
                                 .frame(width: 120, height: 120)
                                 .background(RoundedRectangle(cornerRadius: 8)
@@ -164,7 +162,7 @@ public struct ImagePicker: FormComponent {
                     }
                 }
             }
-            
+
             if showValidationErrors, !validator.isValid(selectedImages.count + existingImages.count), let validatorMessage = validator.message(selectedImages.count + existingImages.count) {
                 HStack(spacing: 5) {
                     Image(systemName: "exclamationmark.circle")
@@ -188,7 +186,7 @@ struct CustomBadgeModifier: ViewModifier {
     let textColor: Color
     let enabled: Bool
     let action: (() -> Void)?
-    
+
     init(text: String? = nil, imageStr: String? = nil, badgeColor: Color = .red, textColor: Color = .white, enabled: Bool = true, action: (() -> Void)? = nil) {
         self.text = text
         self.imageStr = imageStr
@@ -197,7 +195,7 @@ struct CustomBadgeModifier: ViewModifier {
         self.enabled = enabled
         self.action = action
     }
-    
+
     @ViewBuilder
     func badgeView() -> some View {
         ZStack {
@@ -218,7 +216,7 @@ struct CustomBadgeModifier: ViewModifier {
         }
         .offset(x: 10, y: -10)
     }
-    
+
     func body(content: Content) -> some View {
         if enabled {
             if let action = action {
@@ -246,7 +244,7 @@ public extension View {
     func badge(_ text: String, badgeColor: Color = .red, textColor: Color = .white, enabled: Bool = true, action: (() -> Void)? = nil) -> some View {
         self.modifier(CustomBadgeModifier(text: text, badgeColor: badgeColor, textColor: textColor, enabled: enabled, action: action))
     }
-    
+
     func badge(imageStr: String, badgeColor: Color = .red, textColor: Color = .white, enabled: Bool = true, action: (() -> Void)? = nil) -> some View {
         self.modifier(CustomBadgeModifier(imageStr: imageStr, badgeColor: badgeColor, textColor: textColor, enabled: enabled, action: action))
     }

--- a/Sources/PennForms/FormComponents/NumericField.swift
+++ b/Sources/PennForms/FormComponents/NumericField.swift
@@ -95,7 +95,7 @@ public struct NumericField<FormatStyle: ParseableFormatStyle>: FormComponent whe
                   }
                 })
                 .componentFormStyle(
-                    isValid: validator.isValid(value as AnyValidator.Input), validatorMessage: validator.message
+                    isValid: validator.isValid(value as AnyValidator.Input), validatorMessage: validator.message(value as AnyValidator.Input)
                 )
             // Bug with currency formatters, where only works if the currency symbol is deleted when entering the value
                 .onReceive(NotificationCenter.default.publisher(for: UITextField.textDidBeginEditingNotification)) { obj in

--- a/Sources/PennForms/FormComponents/NumericField.swift
+++ b/Sources/PennForms/FormComponents/NumericField.swift
@@ -7,8 +7,7 @@ public struct NumericField<FormatStyle: ParseableFormatStyle>: FormComponent whe
     let title: String?
     let format: FormatStyle
     @Environment(\.validator) private var validator
-    
-    
+
     public init(_ value: Binding<Int?>, placeholder: String? = nil, title: String? = nil) where FormatStyle == Decimal.FormatStyle {
         self._value = Binding(get: {
             guard let v = value.wrappedValue else { return .nan }
@@ -20,12 +19,12 @@ public struct NumericField<FormatStyle: ParseableFormatStyle>: FormComponent whe
         self.title = title
         self.format = .number
         self._validator = Environment(\.validator)
-        
-        // MARK - This is making the pair bug out
+
+        // MARK: - This is making the pair bug out
         UITextField.appearance().text = placeholder ?? ""
         UITextField.appearance().textColor = .secondaryLabel
     }
-    
+
     public init(_ value: Binding<Int?>, format: FormatStyle, placeholder: String? = nil, title: String? = nil) {
         self._value = Binding(get: {
             guard let v = value.wrappedValue else { return .nan }
@@ -38,7 +37,7 @@ public struct NumericField<FormatStyle: ParseableFormatStyle>: FormComponent whe
         self.format = format
         self._validator = Environment(\.validator)
     }
-    
+
     public init(_ value: Binding<Double?>, placeholder: String? = nil, title: String? = nil) where FormatStyle == Decimal.FormatStyle {
         self._value = Binding(get: {
             guard let v = value.wrappedValue else { return .nan }
@@ -50,11 +49,11 @@ public struct NumericField<FormatStyle: ParseableFormatStyle>: FormComponent whe
         self.title = title
         self.format = .number
         self._validator = Environment(\.validator)
-        
+
         UITextField.appearance().text = placeholder ?? ""
         UITextField.appearance().textColor = .secondaryLabel
     }
-    
+
     public init(_ value: Binding<Double?>, placeholder: String? = nil, title: String? = nil, format: FormatStyle) {
         self._value = Binding(get: {
             guard let v = value.wrappedValue else { return .nan }
@@ -67,14 +66,14 @@ public struct NumericField<FormatStyle: ParseableFormatStyle>: FormComponent whe
         self.format = format
         self._validator = Environment(\.validator)
     }
-    
+
     public var body: some View {
         VStack(alignment: .leading) {
             if let title {
                 Text(title)
                     .bold()
             }
-            
+
             TextField(placeholder ?? " ", value: $value, format: format)
                 .introspect(.textField, on: .iOS(.v16...), customize: { textField in
                     if self.value == .nan {
@@ -87,9 +86,9 @@ public struct NumericField<FormatStyle: ParseableFormatStyle>: FormComponent whe
                       }
                     } else {
                         textField.textColor = .label
-                        
+
                     }
-                  
+
                   if textField.isEditing {
                     textField.text = textField.text?.trimmingCharacters(in: CharacterSet(charactersIn: "0123456789.,").inverted)
                   }
@@ -110,19 +109,19 @@ public struct NumericField<FormatStyle: ParseableFormatStyle>: FormComponent whe
 
 extension Decimal.FormatStyle {
     struct RangeFormatter: ParseableFormatStyle {
-        
+
         let range: ClosedRange<Decimal>
         let baseFormatter: Decimal.FormatStyle
-        
+
         init(range: ClosedRange<Decimal>, baseFormatter: Decimal.FormatStyle) {
             self.range = range
             self.baseFormatter = baseFormatter
         }
-        
+
         var parseStrategy: Decimal.ParseStrategy<Decimal.FormatStyle> {
             return baseFormatter.parseStrategy
         }
-        
+
         func format(_ value: FormatInput) -> FormatOutput {
             if value > range.upperBound {
                 return baseFormatter.format(range.upperBound)
@@ -133,10 +132,9 @@ extension Decimal.FormatStyle {
             }
         }
     }
-    
+
     func range(_ range: ClosedRange<Decimal>) -> RangeFormatter {
         return RangeFormatter(range: range, baseFormatter: self)
     }
-    
-    
+
 }

--- a/Sources/PennForms/FormComponents/OptionField.swift
+++ b/Sources/PennForms/FormComponents/OptionField.swift
@@ -51,7 +51,7 @@ public struct OptionField<Option: Hashable>: FormComponent {
             .customPickerStyle(
                 labelText: selection == nil ? nil : toString(selection!), placeholder: placeholder, width: 200, isValid: validator.isValid(selection as AnyValidator.Input)
             )
-            if showValidationErrors, !validator.isValid(selection as AnyValidator.Input), let message = validator.message {
+            if showValidationErrors, !validator.isValid(selection as AnyValidator.Input), let message = validator.message(selection as AnyValidator.Input) {
                 HStack(spacing: 5) {
                     Image(systemName: "exclamationmark.circle")
                     Text(message)

--- a/Sources/PennForms/FormComponents/OptionField.swift
+++ b/Sources/PennForms/FormComponents/OptionField.swift
@@ -6,10 +6,10 @@ public struct OptionField<Option: Hashable>: FormComponent {
     let toString: (Option) -> String
     let title: String?
     let placeholder: String?
-    
+
     @Environment(\.validator) var validator
     @Environment(\.showValidationErrors) var showValidationErrors
-    
+
     public init(_ selection: Binding<Option?>, options: [Option], toString: @escaping (Option) -> String, title: String? = nil, placeholder: String? = nil) {
         self._selection = selection
         self.options = options
@@ -17,7 +17,7 @@ public struct OptionField<Option: Hashable>: FormComponent {
         self.title = title
         self.placeholder = placeholder
     }
-    
+
     public init(_ selection: Binding<Option?>, options: [Option], title: String? = nil, placeholder: String? = nil) where Option: CaseIterable, Option: RawRepresentable<String> {
         self._selection = selection
         self.options = options
@@ -25,7 +25,7 @@ public struct OptionField<Option: Hashable>: FormComponent {
         self.title = title
         self.placeholder = placeholder
     }
-    
+
     public init(_ selection: Binding<Option?>, range: ClosedRange<Int>, title: String? = nil, placeholder: String? = nil) where Option == Int, Option: LosslessStringConvertible {
         self._selection = selection
         self.options = Array(range)
@@ -33,7 +33,7 @@ public struct OptionField<Option: Hashable>: FormComponent {
         self.title = title
         self.placeholder = placeholder
     }
-    
+
     public var body: some View {
         VStack(alignment: .leading) {
             if let title {
@@ -68,9 +68,9 @@ struct CustomPickerStyle: ViewModifier {
     let placeholder: String?
     var width: CGFloat
     let isValid: Bool
-    
+
     @Environment(\.showValidationErrors) var showValidationErrors
-    
+
     func body(content: Content) -> some View {
         Menu {
             content
@@ -91,7 +91,7 @@ struct CustomPickerStyle: ViewModifier {
         .background(.background)
         .overlay(
             RoundedRectangle(cornerRadius: 8)
-                .stroke(isValid || !showValidationErrors ? Color.secondary.opacity(0.3): Color.red , lineWidth: 2)
+                .stroke(isValid || !showValidationErrors ? Color.secondary.opacity(0.3): Color.red, lineWidth: 2)
         )
     }
 }

--- a/Sources/PennForms/FormComponents/PairFields.swift
+++ b/Sources/PennForms/FormComponents/PairFields.swift
@@ -2,11 +2,11 @@ import SwiftUI
 
 public struct PairFields<Content: View>: FormComponent {
     @ViewBuilder let content: () -> Content
-    
+
     public init(@ViewBuilder content: @escaping () -> Content) {
         self.content = content
     }
-    
+
     public var body: some View {
         HStack(alignment: .top) {
             content()

--- a/Sources/PennForms/FormComponents/TagSelector.swift
+++ b/Sources/PennForms/FormComponents/TagSelector.swift
@@ -7,16 +7,16 @@ public struct TagSelector<Tag: Hashable>: FormComponent {
     let toString: (Tag) -> String
     let customisable: Customisable
     let title: String?
-    
+
     @Environment(\.validator) var validator
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.showValidationErrors) var showValidationErrors
-    
+
     public enum Customisable {
         case notCustomisable
         case customisable(tagFromString: (String) -> Tag)
     }
-    
+
     public init(selection: Binding<OrderedSet<Tag>>, tags: Binding<OrderedSet<Tag>>, toString: @escaping (Tag) -> String, _ customisable: Customisable = .notCustomisable, title: String? = nil) {
         self._selection = selection
         self._tags = tags
@@ -25,7 +25,7 @@ public struct TagSelector<Tag: Hashable>: FormComponent {
         self.title = title
         self._validator = Environment(\.validator)
     }
-    
+
     public init(selection: Binding<OrderedSet<Tag>>, tags: Binding<OrderedSet<Tag>>, customisable: Customisable = .notCustomisable, title: String? = nil) where Tag: RawRepresentable<String> {
         self._selection = selection
         self._tags = tags
@@ -34,7 +34,7 @@ public struct TagSelector<Tag: Hashable>: FormComponent {
         self.title = title
         self._validator = Environment(\.validator)
     }
-    
+
     public init(selection: Binding<OrderedSet<Tag>>, tags: Binding<OrderedSet<Tag>>, customisable: Customisable = .notCustomisable, title: String? = nil) where Tag: LosslessStringConvertible {
         self._selection = selection
         self._tags = tags
@@ -43,7 +43,7 @@ public struct TagSelector<Tag: Hashable>: FormComponent {
         self.title = title
         self._validator = Environment(\.validator)
     }
-    
+
     public var body: some View {
         VStack(alignment: .leading) {
             if let title {
@@ -69,7 +69,7 @@ public struct TagSelector<Tag: Hashable>: FormComponent {
                     }
                     .buttonStyle(.plain)
                 }
-            
+
             if showValidationErrors, !validator.isValid(selection as AnyValidator.Input), let message = validator.message(selection as AnyValidator.Input) {
                 HStack(spacing: 5) {
                     Image(systemName: "exclamationmark.circle")
@@ -90,11 +90,11 @@ struct TagGrid<Tag: Hashable, Content: View>: View {
     let alignment: HorizontalAlignment
     let content: (Tag) -> Content
     @State var elementsSize: [Tag: CGSize] = [:]
-    
+
     @State var showTagCreator = false
     @State var newTag = ""
-    
-    var body : some View {
+
+    var body: some View {
         VStack(alignment: alignment, spacing: spacing) {
             ForEach(computeRows(), id: \.self) { rowElements in
                 HStack(spacing: spacing) {
@@ -107,7 +107,7 @@ struct TagGrid<Tag: Hashable, Content: View>: View {
                     }
                 }
             }
-            
+
             if case let .customisable(tagFromString) = customisable {
                 Button(action: { showTagCreator = true }) {
                     HStack {
@@ -143,15 +143,15 @@ struct TagGrid<Tag: Hashable, Content: View>: View {
             }
         }
     }
-    
+
     func computeRows() -> [[Tag]] {
         var rows: [[Tag]] = [[]]
         var currentRow = 0
         var remainingWidth = availableWidth
-        
+
         for element in data {
             let elementSize = elementsSize[element, default: CGSize(width: availableWidth, height: 1)]
-            
+
             if remainingWidth - (elementSize.width + spacing) >= 0 {
                 rows[currentRow].append(element)
             } else {
@@ -159,10 +159,10 @@ struct TagGrid<Tag: Hashable, Content: View>: View {
                 rows.append([element])
                 remainingWidth = availableWidth
             }
-            
+
             remainingWidth = remainingWidth - (elementSize.width + spacing)
         }
-        
+
         return rows
     }
 }

--- a/Sources/PennForms/FormComponents/TagSelector.swift
+++ b/Sources/PennForms/FormComponents/TagSelector.swift
@@ -70,7 +70,7 @@ public struct TagSelector<Tag: Hashable>: FormComponent {
                     .buttonStyle(.plain)
                 }
             
-            if showValidationErrors, !validator.isValid(selection as AnyValidator.Input), let message = validator.message {
+            if showValidationErrors, !validator.isValid(selection as AnyValidator.Input), let message = validator.message(selection as AnyValidator.Input) {
                 HStack(spacing: 5) {
                     Image(systemName: "exclamationmark.circle")
                     Text(message)

--- a/Sources/PennForms/FormComponents/TextAreaField.swift
+++ b/Sources/PennForms/FormComponents/TextAreaField.swift
@@ -51,7 +51,7 @@ public struct TextAreaField: FormComponent {
             
             HStack(spacing: 5) {
                 Group {
-                    if showValidationErrors, !validator.isValid(text), let validatorMessage = validator.message {
+                    if showValidationErrors, !validator.isValid(text), let validatorMessage = validator.message(text) {
                         Image(systemName: "exclamationmark.circle")
                         Text(validatorMessage)
                     }

--- a/Sources/PennForms/FormComponents/TextAreaField.swift
+++ b/Sources/PennForms/FormComponents/TextAreaField.swift
@@ -3,20 +3,20 @@ import SwiftUI
 
 public struct TextAreaField: FormComponent {
     @Binding var text: String
-    
+
     let title: String?
     let characterCount: Int?
-    
+
     @Environment(\.validator) var validator
     @Environment(\.showValidationErrors) var showValidationErrors
-    
+
     public init(_ text: Binding<String>, characterCount: Int? = nil, title: String? = nil) {
         self._text = text
         self.characterCount = characterCount
         self.title = title
         self._validator = Environment(\.validator)
     }
-    
+
     public init(_ text: Binding<String?>, characterCount: Int? = nil, title: String? = nil) {
         self._text = Binding(
             get: {
@@ -29,7 +29,7 @@ public struct TextAreaField: FormComponent {
         self.title = title
         self._validator = Environment(\.validator)
     }
-    
+
     public var body: some View {
         VStack(alignment: .leading) {
             if let title {
@@ -46,9 +46,9 @@ public struct TextAreaField: FormComponent {
                 .cornerRadius(10) // Makes the corners rounded
                 .overlay {
                     RoundedRectangle(cornerRadius: 8)
-                        .stroke(!showValidationErrors || validator.isValid(text) ? Color.secondary.opacity(0.3): Color.red , lineWidth: 2)
+                        .stroke(!showValidationErrors || validator.isValid(text) ? Color.secondary.opacity(0.3): Color.red, lineWidth: 2)
                 }
-            
+
             HStack(spacing: 5) {
                 Group {
                     if showValidationErrors, !validator.isValid(text), let validatorMessage = validator.message(text) {
@@ -58,7 +58,7 @@ public struct TextAreaField: FormComponent {
                 }
                 .foregroundColor(.red)
                 .preference(key: ValidPreferenceKey.self, value: false)
-                
+
                 if let characterCount {
                     Spacer()
                     Text("\(characterCount - text.count) characters remaining")
@@ -75,4 +75,3 @@ public struct TextAreaField: FormComponent {
         .padding(.bottom, 5)
     }
 }
-

--- a/Sources/PennForms/FormComponents/TextLineField.swift
+++ b/Sources/PennForms/FormComponents/TextLineField.swift
@@ -40,7 +40,7 @@ public struct TextLineField: FormComponent {
                     }
                 }
                 .componentFormStyle(
-                    isValid: validator.isValid(text), validatorMessage: validator.message
+                    isValid: validator.isValid(text), validatorMessage: validator.message(text)
                 )
         }
     }

--- a/Sources/PennForms/FormComponents/TextLineField.swift
+++ b/Sources/PennForms/FormComponents/TextLineField.swift
@@ -6,14 +6,14 @@ public struct TextLineField: FormComponent {
     let placeholder: String?
     let title: String?
     @Environment(\.validator) private var validator
-    
+
     public init(_ text: Binding<String>, placeholder: String? = nil, title: String? = nil) {
         self._text = text
         self.placeholder = placeholder
         self.title = title
         self._validator = Environment(\.validator)
     }
-    
+
     public init(_ text: Binding<String?>, placeholder: String? = nil, title: String? = nil) {
         self._text = Binding(
             get: {
@@ -26,7 +26,7 @@ public struct TextLineField: FormComponent {
         self.title = title
         self._validator = Environment(\.validator)
     }
-    
+
     public var body: some View {
         VStack(alignment: .leading) {
             if let title {

--- a/Sources/PennForms/LabsForm.swift
+++ b/Sources/PennForms/LabsForm.swift
@@ -79,7 +79,14 @@ struct TestForm: View {
                     .validator(.required)
                     
                     DateField(date: $date3, placeholder: "Date of birth")
-                        .validator(.required)
+                        .validator([
+                            AnyValidator(.required),
+                            AnyValidator(AtMostValidator(value: date1 ?? (date2 ?? Date.distantFuture), {
+                                let formatter = DateFormatter()
+                                formatter.dateFormat = "MM/dd/yyyy"
+                                return "Must be no later than \(formatter.string(from: $0))"
+                            }))
+                        ])
                     
                     PairFields {
                         OptionField($numRommates, range: 0...4, title: "# roommates")

--- a/Sources/PennForms/LabsForm.swift
+++ b/Sources/PennForms/LabsForm.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 public struct FormState {
     public var isValid: Bool
-    
+
     public init(isValid: Bool) {
         self.isValid = isValid
     }
@@ -12,11 +12,11 @@ public struct FormState {
 public struct LabsForm<Content: FormComponent>: View {
     @FormBuilder let content: (FormState) -> Content
     @State private var formState: FormState = .init(isValid: true)
-    
+
     public init(@FormBuilder content: @escaping (FormState) -> Content) {
         self.content = content
     }
-    
+
     public var body: some View {
         content(formState)
             .onPreferenceChange(ValidPreferenceKey.self) { isValid in
@@ -31,42 +31,41 @@ extension VStack: FormComponent {}
 extension TextField: FormComponent {}
 extension Text: FormComponent {}
 
-
 struct TestForm: View {
     @State private var name: String?
     @State var selectedImages: [UIImage] = []
     @State var existingImages: [String] = []
     @State private var description: String?
-    @State private var date1: Date? = nil
-    @State private var date2: Date? = nil
-    @State private var date3: Date? = nil
-    @State private var numRommates: Int? = nil
-    @State private var negotiable: Negotiable? = nil
-    @State private var price: Double? = nil
+    @State private var date1: Date?
+    @State private var date2: Date?
+    @State private var date3: Date?
+    @State private var numRommates: Int?
+    @State private var negotiable: Negotiable?
+    @State private var price: Double?
     @State private var selectedAmenities: OrderedSet<String> = []
-    
+
     @State private var amenities: OrderedSet = ["Gym", "Private bathroom", "asd", "asdas", "qweuh"]
-    
+
     @State var showValidationErrors = false
-    
+
     var dateRange: ClosedRange<Date> {
         let upper = Date.distantFuture
         return .now...upper
     }
-    
+
     var body: some View {
         NavigationStack {
             ScrollView {
                 LabsForm { formState in
                     TextLineField($name, placeholder: "Name")
                         .validator(.required)
-                    
+
                     ImagePicker($selectedImages, existingImages: $existingImages, maxSelectionCount: 5)
                         .validator(AtLeastValidator(value: 1, { "Must select at least \($0) image\($0 == 1 ? "" : "s")" }))
-                    
+
                     TextAreaField($description, characterCount: 15, title: "Description")
                         .validator(.required)
-                    
+
                     DateRangeField(
                         lowerDate: $date1,
                         upperDate: $date2,
@@ -77,7 +76,7 @@ struct TestForm: View {
                         upperPlaceholder: "End date"
                     )
                     .validator(.required)
-                    
+
                     DateField(date: $date3, placeholder: "Date of birth")
                         .validator([
                             AnyValidator(.required),
@@ -87,7 +86,7 @@ struct TestForm: View {
                                 return "Must be no later than \(formatter.string(from: $0))"
                             }))
                         ])
-                    
+
                     PairFields {
                         OptionField($numRommates, range: 0...4, title: "# roommates")
                             .validator(.required)
@@ -97,17 +96,17 @@ struct TestForm: View {
                         )
                         .validator(.required)
                     }
-                    
+
                     NumericField(
                         $price,
                         title: "Price",
                         format: .currency(code: "USD").presentation(.narrow)
                     )
                     .validator(.required)
-                    
+
                     TagSelector(selection: $selectedAmenities, tags: $amenities, customisable: .customisable(tagFromString: { $0}), title: "Amenities")
                         .validator(.required)
-                    
+
                     ComponentWrapper {
                         Button(action: {
                             showValidationErrors = true

--- a/Sources/PennForms/Validators/AlwaysValidator.swift
+++ b/Sources/PennForms/Validators/AlwaysValidator.swift
@@ -2,6 +2,6 @@ public struct AlwaysValidator: Validator {
     public func isValid(_ input: Any) -> Bool {
         true
     }
-    
-    public let message: String? = nil
+
+    public let message: (Input?) -> String? = { _ in nil }
 }

--- a/Sources/PennForms/Validators/AnyValidator.swift
+++ b/Sources/PennForms/Validators/AnyValidator.swift
@@ -1,27 +1,32 @@
 public struct AnyValidator: Validator {
     public typealias Input = Any
     let validator: (Any) -> Bool
-    public let message: String?
-    
+    public let message: (Input?) -> String?
+
     public func isValid(_ input: Input) -> Bool {
         self.validator(input)
     }
-    
+
     public init<V: Validator>(_ validator: V) where V.Input: Any {
         self.validator = { input in
-            guard let castInput = input as? V.Input else { return false}
+            guard let castInput = input as? V.Input else {
+                return false
+            }
             return validator.isValid(castInput)
         }
-        self.message = validator.message
+        self.message = { input in
+            guard let castInput = input as? V.Input else {
+                return nil
+            }
+            return validator.message(castInput)
+        }
     }
-    
+
     public init(_ isValid: @escaping () -> Bool, message: String? = nil) {
         self.validator = { _ in isValid() }
-        self.message = message
-        
+        self.message = { _ in message }
     }
 }
-
 
 public extension Validator where Self == AnyValidator {
     static func `any`<V: Validator>(_ validator: V) -> AnyValidator {

--- a/Sources/PennForms/Validators/AtMostValidator.swift
+++ b/Sources/PennForms/Validators/AtMostValidator.swift
@@ -1,14 +1,14 @@
 //
-//  AtLeastValidator.swift
+//  AtMostValidator.swift
 //
 //
-//  Created by Jordan H on 3/6/24.
+//  Created by Jordan H on 4/4/25.
 //
 
 import Foundation
 import OrderedCollections
 
-public struct AtLeastValidator<T: Comparable>: Validator {
+public struct AtMostValidator<T: Comparable>: Validator {
     public let message: (Input?) -> String?
     public let limit: T
 
@@ -25,13 +25,13 @@ public struct AtLeastValidator<T: Comparable>: Validator {
 
     public init(value: T) {
         self.limit = value
-        self.message = { _ in "Must be at least \(value)" }
+        self.message = { _ in "Must be at most \(value)" }
     }
 
     public typealias Input = Any
     public func isValid(_ input: Any) -> Bool {
         if let input = input as? T {
-            return input >= limit
+            return input <= limit
         } else {
             return true
         }
@@ -39,7 +39,7 @@ public struct AtLeastValidator<T: Comparable>: Validator {
 }
 
 public extension Validator {
-    func atLeast<T: Comparable>(value: T, _ message: String) -> Self { AtLeastValidator(value: value, message) as! Self }
+    func atMost<T: Comparable>(value: T, _ message: String) -> Self { AtMostValidator(value: value, message) as! Self }
 
-    func atLeast<T: Comparable>(value: T) -> Self { AtLeastValidator(value: value) as! Self }
+    func atMost<T: Comparable>(value: T) -> Self { AtMostValidator(value: value) as! Self }
 }

--- a/Sources/PennForms/Validators/BetweenValidator.swift
+++ b/Sources/PennForms/Validators/BetweenValidator.swift
@@ -1,0 +1,49 @@
+//
+//  BetweenValidator.swift
+//
+//
+//  Created by Jordan H on 3/6/24.
+//
+
+import Foundation
+import OrderedCollections
+
+public struct BetweenValidator<T: Comparable>: Validator {
+    public let message: (Input?) -> String?
+    public let lowLimit: T
+    public let highLimit: T
+
+    public init(lowLimit: T, highLimit: T, _ message: (T, T) -> String) {
+        self.lowLimit = lowLimit
+        self.highLimit = highLimit
+        let finalMessage = message(lowLimit, highLimit)
+        self.message = { _ in finalMessage }
+    }
+
+    public init(lowLimit: T, highLimit: T, _ message: String) {
+        self.lowLimit = lowLimit
+        self.highLimit = highLimit
+        self.message = { _ in message }
+    }
+
+    public init(lowLimit: T, highLimit: T) {
+        self.lowLimit = lowLimit
+        self.highLimit = highLimit
+        self.message = { _ in "Must be between \(lowLimit) and \(highLimit)" }
+    }
+
+    public typealias Input = Any
+    public func isValid(_ input: Any) -> Bool {
+        if let input = input as? T {
+            return input >= lowLimit && input <= highLimit
+        } else {
+            return true
+        }
+    }
+}
+
+public extension Validator {
+    func between<T: Comparable>(lowLimit: T, highLimit: T, _ message: String) -> Self { BetweenValidator(lowLimit: lowLimit, highLimit: highLimit, message) as! Self }
+
+    func between<T: Comparable>(lowLimit: T, highLimit: T) -> Self { BetweenValidator(lowLimit: lowLimit, highLimit: highLimit) as! Self }
+}

--- a/Sources/PennForms/Validators/ManyValidator.swift
+++ b/Sources/PennForms/Validators/ManyValidator.swift
@@ -8,7 +8,8 @@ public struct ManyValidators: Validator {
     public init(_ validators: [AnyValidator]) {
         self.validators = validators
         self.message = { input in
-            if let firstFailure = validators.first { !$0.isValid(input) } {
+            guard let input else { return nil }
+            if let firstFailure = validators.first(where: { !$0.isValid(input) }) {
                 return firstFailure.message(input)
             } else {
                 return nil

--- a/Sources/PennForms/Validators/ManyValidator.swift
+++ b/Sources/PennForms/Validators/ManyValidator.swift
@@ -2,18 +2,23 @@ import SwiftUI
 
 public struct ManyValidators: Validator {
     public typealias Input = Any
+    public let message: (Input?) -> String?
     let validators: [AnyValidator]
-    
+
     public init(_ validators: [AnyValidator]) {
         self.validators = validators
-        self.message =  validators[0].message
+        self.message = { input in
+            if let firstFailure = validators.first { !$0.isValid(input) } {
+                return firstFailure.message(input)
+            } else {
+                return nil
+            }
+        }
     }
-    
+
     public func isValid(_ input: Input) -> Bool {
         return validators.allSatisfy { $0.isValid(input) }
     }
-    
-    public var message: String?
 }
 
 public extension View {

--- a/Sources/PennForms/Validators/NeverValidator.swift
+++ b/Sources/PennForms/Validators/NeverValidator.swift
@@ -2,6 +2,6 @@ public struct NeverValidator: Validator {
     public func isValid(_ input: Any) -> Bool {
         false
     }
-    
-    public let message: String? = nil
+
+    public let message: (Input?) -> String? = { _ in nil }
 }

--- a/Sources/PennForms/Validators/NotNilValidator.swift
+++ b/Sources/PennForms/Validators/NotNilValidator.swift
@@ -3,10 +3,10 @@ public struct NotNilValidator: Validator {
     public func isValid(_ input: Input) -> Bool {
         input != nil
     }
-    
-    public var message: String? = "Choose an option"
+
+    public let message: (Input?) -> String? = { _ in "Choose an option" }
 }
 
 public extension Validator where Self == NotNilValidator {
-    static var notNil: NotNilValidator {  NotNilValidator() }
+    static var notNil: NotNilValidator { NotNilValidator() }
 }

--- a/Sources/PennForms/Validators/RequiredValidator.swift
+++ b/Sources/PennForms/Validators/RequiredValidator.swift
@@ -2,30 +2,27 @@ import Foundation
 import OrderedCollections
 
 public struct RequiredValidator: Validator {
-    public let message: String?
-    
+    public let message: (Input?) -> String?
+
     public init(_ message: String = "Required field") {
-        self.message = message
+        self.message = { _ in message }
     }
-    
+
     public typealias Input = Any
     public func isValid(_ input: Any) -> Bool {
-
         if let input = input as? (any HasEmpty) {
             return !input.empty
-        } else if let input = input as? Optional<Any> {
+        } else if let input = input as? Any? {
             return input != nil
         } else {
             return true
         }
-        
     }
-    
 }
 
 public extension Validator where Self == RequiredValidator {
     static var required: Self { RequiredValidator() }
-    
+
     func required(_ message: String) -> Self { RequiredValidator(message) }
 }
 

--- a/Sources/PennForms/Validators/Validator.swift
+++ b/Sources/PennForms/Validators/Validator.swift
@@ -3,7 +3,11 @@ import SwiftUI
 public protocol Validator<Input> {
     associatedtype Input
     func isValid(_ input: Input) -> Bool
-    var message: String? { get }
+
+    // This is a function because the message might depend on the input
+    // For example, in ManyValidator, the first validator might pass, while the second fails
+    // Thus we need to show the second validator's message (hence it is input dependent)
+    var message: (Input?) -> String? { get }
 }
 
 public extension Validator {
@@ -27,7 +31,7 @@ public extension View {
     func validator<V: Validator>(_ validator: V) -> some FormComponent where V.Input: Any {
         ComponentWrapper { self.environment(\.validator, AnyValidator(validator)) }
     }
-    
+
     func validator(_ isValid: @escaping () -> Bool, message: String? = nil) -> some FormComponent {
         ComponentWrapper { self.environment(\.validator, AnyValidator(isValid, message: message)) }
     }


### PR DESCRIPTION
This PR started as a result of me trying to use `ManyValidator`, which uses multiple validators at once. However, I realized the current implementation was slightly broken in that the error message was always the first validator's error message.

For example, if on a field I added a `RequiredValidator`, and an `AtMostValidator`, and the field was filled in but too large, then the error displayed would have been the `RequiredValidator`'s message, which doesn't make sense.

As a result, it is clear that the validator messages need to be input dependent. Now for most of the validators, this doesn't actually mean we should change the message depending on the input, which is why you see I'm setting most of the built in validator messages to `{ _ in message }` or something of the like. The only one that actually behaves different is the `ManyValidator`, which now returns the message of the first validator that fails.

I also added an `AtLeastValidator`, `AtMostValidator`, and `BetweenValidator`.

-------------------------------

This also fixes a crash bug with `DateRangeField` if the start date was before the current date (which caused the start date of the range to be after the end date).

The new behavior is that any start date and end date can be chosen as long as they are in the provided range, but if start date is after end date, a validation error is shown. (As opposed to just not being able to select a start date past the end date in the first place.)

This PR is needed for https://github.com/pennlabs/penn-mobile-ios/pull/601.